### PR TITLE
:bug: Fix #9 Cannot reserve, resize nor emplace_back in std::vector<t…

### DIFF
--- a/example/forward.cpp
+++ b/example/forward.cpp
@@ -25,7 +25,7 @@ struct Circle {
 // cpp
 void draw(te::poly<Drawable> const &drawable) { drawable.draw(std::cout); }
 
-void Drawable::draw(std::ostream& out) const {
+void Drawable::draw(std::ostream &out) const {
   te::call([](auto const &self, auto &out) { self.draw(out); }, *this, out);
 }
 

--- a/test/te.cpp
+++ b/test/te.cpp
@@ -233,10 +233,11 @@ test should_support_movable_only_types_with_local_storage = [] {
 
 test should_support_containers = [] {
   std::vector<te::poly<Drawable>> drawables{};
+  drawables.reserve(42);
 
   drawables.push_back(Square{});
   drawables.push_back(Circle{});
-  drawables.push_back(Triangle{});
+  drawables.emplace_back(Triangle{});
 
   std::stringstream str{};
   for (const auto &drawable : drawables) {


### PR DESCRIPTION
…e::poly<Type>>

Problem:
- is_move_constructible is called with a forwarding reference instead of a decayed type.

Solution:
- std::decay the forwarding reference before applying is_move_constructible in the poly constructor.