### PR TITLE
:new: :art: Boostify

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 cmake_minimum_required(VERSION 2.8)
-project(Type.Erasure CXX)
+project(Boost.TE CXX)
 
 option(ENABLE_MEMCHECK "Run the unit tests and examples under valgrind if it is found." OFF)
 option(ENABLE_COVERAGE "Run coverage." OFF)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Type.Erasure <a href="http://www.boost.org/LICENSE_1_0.txt" target="_blank">![Boost Licence](http://img.shields.io/badge/license-boost-blue.svg)</a> <a href="https://travis-ci.org/boost-experimental/te" target="_blank">![Build Status](https://img.shields.io/travis/boost-experimental/te/master.svg?label=linux/osx)</a> <a href="https://codecov.io/gh/boost-experimental/te" target="_blank">![Coveralls](https://codecov.io/gh/boost-experimental/te/branch/master/graph/badge.svg)</a> <a href="http://github.com/boost-experimental/te/issues" target="_blank">![Github Issues](https://img.shields.io/github/issues/boost-experimental/te.svg)</a> <a href="https://godbolt.org/g/jwyvka">![Try it online](https://img.shields.io/badge/try%20it-online-blue.svg)</a>
+# [Boost].TE <a href="http://www.boost.org/LICENSE_1_0.txt" target="_blank">![Boost Licence](http://img.shields.io/badge/license-boost-blue.svg)</a> <a href="https://travis-ci.org/boost-experimental/te" target="_blank">![Build Status](https://img.shields.io/travis/boost-experimental/te/master.svg?label=linux/osx)</a> <a href="https://codecov.io/gh/boost-experimental/te" target="_blank">![Coveralls](https://codecov.io/gh/boost-experimental/te/branch/master/graph/badge.svg)</a> <a href="http://github.com/boost-experimental/te/issues" target="_blank">![Github Issues](https://img.shields.io/github/issues/boost-experimental/te.svg)</a> <a href="https://godbolt.org/g/jwyvka">![Try it online](https://img.shields.io/badge/try%20it-online-blue.svg)</a>
 
-> Your C++17 **one header only** run-time polymorphism library with no dependencies, macros and limited boilerplate
+> Your C++17 **one header only** run-time polymorphism (type erasure) library with no dependencies, macros and limited boilerplate
 
 * *Duck typing ([No inheritance](https://en.wikipedia.org/wiki/Duck_typing))*
 * *Value semantics ([Value vs reference semantics](https://isocpp.org/wiki/faq/value-vs-ref-semantics))*
@@ -10,10 +10,11 @@
 
 ### Quick start
 
-> Type.Erasure requires only one file. Get the latest header [here!](https://github.com/boost-experimental/te/blob/master/include/te.hpp)
+> [Boost].TE requires only one file. Get the latest header [here!](https://github.com/boost-experimental/te/blob/master/include/te.hpp)
 
 ```cpp
-#include <te.hpp> // Requires C++17 (Tested: GCC-6+, Clang-4.0+, Apple:Clang-9.1+)
+#include <boost/te.hpp> // Requires C++17 (Tested: GCC-6+, Clang-4.0+, Apple:Clang-9.1+)
+namespace te = boost::te;
 ```
 
 #### Erase it
@@ -394,4 +395,4 @@ int main() {
 
 ---
 
-**Disclaimer** `Type.Erasure` is an experimental library.
+**Disclaimer** `[Boost].TE` is not an official Boost library.

--- a/example/combined.cpp
+++ b/example/combined.cpp
@@ -7,7 +7,9 @@
 //
 #include <iostream>
 
-#include "te.hpp"
+#include "boost/te.hpp"
+
+namespace te = boost::te;
 
 struct Drawable : te::poly<Drawable> {
   using te::poly<Drawable>::poly;

--- a/example/concepts.cpp
+++ b/example/concepts.cpp
@@ -8,7 +8,9 @@
 #if defined(__cpp_concepts)
 #include <iostream>
 
-#include "te.hpp"
+#include "boost/te.hpp"
+
+namespace te = boost::te;
 
 struct Drawable {
   void draw(std::ostream &out) const {

--- a/example/container.cpp
+++ b/example/container.cpp
@@ -8,7 +8,9 @@
 #include <iostream>
 #include <vector>
 
-#include "te.hpp"
+#include "boost/te.hpp"
+
+namespace te = boost::te;
 
 struct Drawable {
   void draw(std::ostream &out) const {

--- a/example/drawable.cpp
+++ b/example/drawable.cpp
@@ -7,7 +7,9 @@
 //
 #include <iostream>
 
-#include "te.hpp"
+#include "boost/te.hpp"
+
+namespace te = boost::te;
 
 struct Drawable {
   void draw(std::ostream &out) const {

--- a/example/forward.cpp
+++ b/example/forward.cpp
@@ -7,7 +7,9 @@
 //
 #include <iostream>
 
-#include "te.hpp"
+#include "boost/te.hpp"
+
+namespace te = boost::te;
 
 // header
 struct Drawable {

--- a/example/function.cpp
+++ b/example/function.cpp
@@ -7,7 +7,9 @@
 //
 #include <cassert>
 
-#include "te.hpp"
+#include "boost/te.hpp"
+
+namespace te = boost::te;
 
 template <class>
 struct Function;

--- a/example/injection.cpp
+++ b/example/injection.cpp
@@ -9,7 +9,9 @@
 #include <boost/di.hpp>
 #include <iostream>
 
-#include "te.hpp"
+#include "boost/te.hpp"
+
+namespace te = boost::te;
 
 struct Drawable : te::poly<Drawable> {
   using te::poly<Drawable>::poly;

--- a/example/macro.cpp
+++ b/example/macro.cpp
@@ -7,7 +7,9 @@
 //
 #include <cassert>
 
-#include "te.hpp"
+#include "boost/te.hpp"
+
+namespace te = boost::te;
 
 struct Addable {
   constexpr auto add(int i) -> REQUIRES(int, add, i);

--- a/example/overload.cpp
+++ b/example/overload.cpp
@@ -7,7 +7,9 @@
 //
 #include <cassert>
 
-#include "te.hpp"
+#include "boost/te.hpp"
+
+namespace te = boost::te;
 
 struct Addable {
   constexpr auto add(int i) { return te::call<int>(add_impl, *this, i); }

--- a/example/override.cpp
+++ b/example/override.cpp
@@ -7,7 +7,9 @@
 //
 #include <iostream>
 
-#include "te.hpp"
+#include "boost/te.hpp"
+
+namespace te = boost::te;
 
 namespace v1 {
 struct Drawable {

--- a/example/storage.cpp
+++ b/example/storage.cpp
@@ -7,7 +7,9 @@
 //
 #include <iostream>
 
-#include "te.hpp"
+#include "boost/te.hpp"
+
+namespace te = boost::te;
 
 struct Drawable {
   void draw(std::ostream &out) const {

--- a/example/unified.cpp
+++ b/example/unified.cpp
@@ -8,7 +8,9 @@
 #include <experimental/type_traits>
 #include <iostream>
 
-#include "te.hpp"
+#include "boost/te.hpp"
+
+namespace te = boost::te;
 
 void draw(struct Circle const &, std::ostream &);
 

--- a/include/boost/te.hpp
+++ b/include/boost/te.hpp
@@ -13,13 +13,13 @@
     not defined(__cpp_return_type_deduction) or                                \
     not defined(__cpp_fold_expressions) or not defined(__cpp_static_assert) or \
     not defined(__cpp_delegating_constructors)
-#error "Type.Erasure requires C++17 support"
+#error "[Boost].TE requires C++17 support"
 #else
 #pragma GCC system_header
 #include <type_traits>
 #include <utility>
 
-namespace te {
+namespace boost::te {
 inline namespace v1 {
 namespace detail {
 template <class...>
@@ -296,7 +296,7 @@ concept bool conceptify = requires {
 #endif
 
 }  // namespace v1
-}  // namespace te
+}  // namespace boost::te
 
 #if not defined(REQUIRES)
 #define REQUIRES(R, name, ...)                                              \

--- a/test/te.cpp
+++ b/test/te.cpp
@@ -10,7 +10,9 @@
 #include <vector>
 
 #include "common/test.hpp"
-#include "te.hpp"
+#include "boost/te.hpp"
+
+namespace te = boost::te;
 
 test should_set_get_mappings = [] {
   struct B {};


### PR DESCRIPTION
Problem:
- TE is in boost-experimental repo, however is not boostified.

Solution:
- Use boost directory structure.
- Use boost namespace.
- Use [Boost].TE instead of TE as the library name (brackets because it's not an official library).