### PR TITLE
Fixed typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ namespace v2 {
 
     // override
     void draw(std::ostream &out) const {
-      te::call([](auto const &self, auto &&... args) { self.draw(args...); }, *this, out, "v3");
+      te::call([](auto const &self, auto &&... args) { self.draw(args...); }, *this, out, "v2");
     }
 
     // extend/overload


### PR DESCRIPTION
I found a typo.

The comment indicates that "v3" should be "v2".

```cpp
  draw<v2::Drawable>(Circle{});    // prints v2::Circle
  draw<v2::Drawable>(Circle{}, 1); // prints v2.1::Circle
  draw<v2::Drawable>(Square{});    // prints v2::Square
  draw<v2::Drawable>(Square{}, 2); // prints v2.2::Square
```